### PR TITLE
remove anti-diagonal for linear chromosomes

### DIFF
--- a/sim3C.py
+++ b/sim3C.py
@@ -1591,6 +1591,9 @@ if __name__ == '__main__':
         # extract these parameters from the parsed arguments
         kw_args = {k: v for k, v in vars(args).items() if k in kw_names}
 
+        if kw_args["linear"]:
+	    kw_args["anti_rate"] = 0
+
         # initialise a sequencing strategy for this community
         # and the given experimental parameters
         strategy = SequencingStrategy(args.seed, args.profile_in, args.genome_seq, args.enzyme_name,


### PR DESCRIPTION
As far as I know linear chromosomes don't have anti-diagonal interactions, so the anti-diagonal option should automatically be set to 0 if --linear is set 