### PR TITLE
Add support for specifyign a bridge adapter for more complete simulation of Dnase Hi-C. 

### DIFF
--- a/sim3C/art.py
+++ b/sim3C/art.py
@@ -441,6 +441,7 @@ class SeqRead:
         self.indel = {}
         self.del_rate = del_rate
         self.ins_rate = ins_rate
+        self.cigar = []
 
     def _new_read(self, rlen=None, plus_strand=True):
         """
@@ -625,6 +626,7 @@ class SeqRead:
             # straight to an result if no indels, where here seq_ref
             # has already been chopped to the read length.
             self.seq_read = self.seq_ref
+            self.cigar.append([0, self.read_len])
 
         else:
             # otherwise, we gotta a little more work to do.
@@ -639,20 +641,36 @@ class SeqRead:
                     n += 1
                     i += 1
                     k += 1
+                    if len(self.cigar)> 0 and self.cigar[-1][0] == 0:
+                        self.cigar[-1][1] += 1
+                    else:
+                        self.cigar.append([0, 1])
                 elif self.indel[k] == '-':
                     # deletion
                     i += 1
                     k += 1
+                    if len(self.cigar)> 0 and self.cigar[-1][0] == 2:
+                        self.cigar[-1][1] += 1
+                    else:
+                        self.cigar.append([2, 1])
                 else:
                     # insertion
                     self.seq_read[n] = self.indel[k]
                     n += 1
                     k += 1
+                    if len(self.cigar)> 0 and self.cigar[-1][0] == 1:
+                        self.cigar[-1][1] += 1
+                    else:
+                        self.cigar.append([1, 1])
 
             while k in self.indel:
                 self.seq_read[n] = self.indel[k]
                 n += 1
                 k += 1
+                if len(self.cigar)> 0 and self.cigar[-1][0] == 1:
+                    self.cigar[-1][1] += 1
+                else:
+                    self.cigar.append([1, 1])
 
     def length(self):
         """

--- a/sim3C/community.py
+++ b/sim3C/community.py
@@ -232,7 +232,6 @@ class Replicon:
         :param rev: reverse complement this sequence.
         :return: subseq Seq object
         """
-
         # handle negative starts as wrapping around or,
         # in linear cases, terminates at first position
         if x1 < 0:
@@ -243,7 +242,8 @@ class Replicon:
         if diff > 0:
             if self.linear:
                 # sequence terminates early
-                ss = self.seq[x1:-1]
+                x1 = max(0, self.length - length)
+                ss = self.seq[x1:]
                 ss.description = Replicon.PART_DESC_FMT.format(rev, x1+1, self.length)
             else:
                 # sequence will wrap around
@@ -254,9 +254,9 @@ class Replicon:
             ss.description = Replicon.PART_DESC_FMT.format(rev, x1+1, x2)
 
         if rev:
-            ss.reverse_complement(id=True, description=True)
+            ss = ss.reverse_complement(id=True, description=True)
 
-        return ss
+        return ss, x1
 
 
 class Cell:


### PR DESCRIPTION
**Change Points**
- Fixed a bug in ligation site creation
When Hi-C reads were created with HindIII (A^AGCTT), the ligation site should be AAGCTAGCTT as for as I know, but in sim3C, it was AAGCTAGCTAGCTT. So I fixed it.

- Fixed an error that occurred when using the linear option
Errors sometimes occur when using the linear option. So I fixed it.
<img width="1121" alt="スクリーンショット 2022-09-27 17 26 14" src="https://user-images.githubusercontent.com/100332387/192474547-2c8f8e47-c19c-4d9c-9c7a-6c5a45a745be.png">

- Set initial value of efficiency when -m dnase option is used
The initial value of efficiency was not specified when using -m dnase option, so it was set.

- Fixed a bug in which read orientation was fixed when creating Hi-C reads
In sim3C, the orientation of the reads was fixed as shown in the figure below. But as for as I know, the orientation of the Hi-C reads is generally random. So I fixed it.
<img width="367" alt="スクリーンショット 2022-09-27 17 29 33" src="https://user-images.githubusercontent.com/100332387/192475116-0b6d9782-afcd-4039-87ad-77f5d322a4fa.png">

- Added --bridge-adapter option
Added the function to insert a bridge adapter sequence when using the -m dnase option.

- Added --sam option
Added the function to output SAM format files.