### PR TITLE
Merging major change to master, resolves issue #29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm
+FROM python:3.11-bookworm as build
 
 LABEL maintainer="matt.demaere@gmail.com"
 LABEL org.label-schema.schema-version="1.0"
@@ -16,7 +16,13 @@ RUN apt-get update &&  \
     pip install -U pip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install git+https://github.com/cerebis/sim3C.git
+RUN pip install git+https://github.com/cerebis/sim3C.git && \
+    sim3C --help
+
+FROM python:3.11-slim as run
+
+COPY --from=build /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=build /usr/local/bin/sim3C /usr/local/bin/sim3C
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-bookworm
+
+LABEL maintainer="matt.demaere@gmail.com"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="cerebis/qc3c"
+LABEL org.label-schema.description="sim3C: read-pair simulation of 3C-based sequencing methodologies (HiC, Meta3C, DNase-HiC)"
+LABEL org.label-schema.url="http://github.com/cerebis/sim3C/"
+LABEL org.label-schema.vcs-url="http://github.com/cerebis/sim3C/"
+#LABEL org.label-schema.vcs-ref="07cc4cd7e938950f9242df255d365d065b62d0a8"
+LABEL org.label-schema.version="0.5"
+LABEL org.label-schema.docker.cmd="docker run -v /path/to/data:/app cerebis/sim3c --help"
+
+RUN apt-get update &&  \
+    apt-get upgrade -y && \
+    apt-get install -y llvm && \
+    pip install -U pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install git+https://github.com/cerebis/sim3C.git
+
+RUN mkdir -p /app
+WORKDIR /app
+ENTRYPOINT ["sim3C"]
+CMD ["--help"]

--- a/sim3C/_version.py
+++ b/sim3C/_version.py
@@ -1,4 +1,4 @@
-__version__ = '0.5'
+__version__ = '0.6'
 
 __copyright__ = """Copyright (C) 2019 Matthew Z DeMaere
 This is free software.  You may redistribute copies of it under the terms of

--- a/sim3C/community.py
+++ b/sim3C/community.py
@@ -1,29 +1,199 @@
 import logging
 import numpy as np
+from numba import njit
 
 from collections import OrderedDict
 
-from .empirical_model import EmpiricalDistribution, generate_nested_cids, cids_to_blocks, cdf_geom_unif_ratio
+# from .empirical_model import EmpiricalDistribution, cdf_geom_unif_ratio, generate_nested_cids, cids_to_blocks
+from .empirical_model import EmpiricalDistribution, cdf_geom_unif_ratio
 from .exceptions import *
 from .site_analysis import AllSites, CutSites
-from .random import np_choice
 import sim3C.random as random
 
 logger = logging.getLogger(__name__)
 
 
+@njit("i4(f8[:], f8)")
+def random_index(cdf, rv):
+    """
+    A weighted number draw, functioning like numpy.random.choice. This
+    approach is faster than choice, which also cannot be Numba-compiled
+    when supplying weights. Additionally, with JIT compilation this
+    is a further 3X faster than without. Note: we cannot make the call to
+    pcg_uniform() from here as Numba cannot infer its return type.
+    """
+    return np.searchsorted(cdf, rv)
+
+
 def cdf_choice(vals, cdf):
     """
     Random selection of an element from an array, biased by the supplied CDF.
-
-    TODO this function should be compared for performance against just using random.choice or np.random.choice.
-       I expect this has been done, but I do not remember. Otherwise, this may be a candidate for numba.
-
     :param vals: the array of potential choices
     :param cdf: the CDF describing each elements probability of selection
     :return: the selected element
     """
-    return vals[np.searchsorted(cdf, pcg_uniform())]
+    # TODO explore whether moving this method to faster.pyx would be faster
+    return vals[random_index(cdf, pcg_uniform())]
+
+
+class Segment(object):
+    """
+    A segment of DNA sequence which may represent all or only part of a complete
+    replicon (chromosome, plasmid, etc).
+    """
+
+    def __init__(self, name, repl, seq, enzyme, anti_rate, create_cids=True, linear=False):
+        """
+        The definition of a segment of DNA.
+        :param name: a unique name for this segment
+        :param repl: the parent replicon for this segment
+        :param seq: the sequence of this segment
+        :param enzyme: the enzyme used to digest DNA in the 3C/HiC library preparation
+        :param anti_rate: the rate of anti-diagonal interactions
+        :param create_cids: when true, simulate chromosome-interacting-domains
+        :param linear: treat replicons as linear
+        """
+        self.name = name
+        self.seq = seq
+        self.linear = linear
+
+        self.parent_repl = repl
+        repl.register_segment(self)
+
+        # cut-site related properties. These are pre-calculated as a simple
+        # means of avoiding performance penalties with repeated calls.
+        if not enzyme:
+            self.sites = AllSites(len(seq.seq))
+        else:
+            self.sites = CutSites(enzyme, seq.seq, linear=linear)
+
+        self.length = len(self.seq)
+        self.num_sites = self.sites.size
+        self.site_density = self.num_sites / self.length
+
+        if create_cids:
+            logger.warning('CID model currently disabled')
+        self.draw_constrained_site = self._draw_simple_constrained_site
+
+        if self.linear:
+            if anti_rate > 0:
+                logger.warning('Replicon {} is linear, anti_rate of {} has been set to zero'
+                               .format(name, anti_rate))
+            self.anti_rate = 0
+        else:
+            self.anti_rate = anti_rate
+
+        # setup for simple model
+        self.empdist = EmpiricalDistribution(self.length,
+                                             Replicon.GLOBAL_EMPDIST_BINS, cdf_geom_unif_ratio,
+                                             cdf_alpha=Replicon.CDF_ALPHA,
+                                             shape=Replicon.GLOBAL_SHAPE_FACTOR)
+
+    def __repr__(self):
+        return '{} {}'.format(self.name, self.parent_repl)
+
+    def subseq(self, pos1, length, rev=False):
+        """
+        Create a subsequence.
+
+        :param pos1: starting genomic position
+        :param length: length of subsequence
+        :param rev: reverse complement this sequence.
+        :return: subseq Seq object
+        """
+
+        # handle negative starts as wrapping around or,
+        # in linear cases, terminates at first position
+        if pos1 < 0:
+            pos1 = pos1 % self.length if not self.linear else 0
+
+        pos2 = pos1 + length
+        diff = pos2 - self.length
+        if diff > 0:
+            if self.linear:
+                # sequence terminates early
+                ss = self.seq[pos1:-1]
+                ss.description = Replicon.PART_DESC_FMT.format(rev, pos1 + 1, self.length)
+            else:
+                # sequence will wrap around
+                ss = self.seq[pos1:] + self.seq[:diff]
+                ss.description = Replicon.PART_DESC_FMT.format(rev, pos1 + 1, diff)
+        else:
+            ss = self.seq[pos1:pos2]
+            ss.description = Replicon.PART_DESC_FMT.format(rev, pos1 + 1, pos2)
+
+        if rev:
+            ss.reverse_complement(id=True, description=True)
+
+        return ss
+
+    def covers_site(self, pos, length):
+        """
+        Test if the segment defined by a position and length cover any cut-sites
+        for this replicon and enzyme digestion.
+        :param pos: the beginning position
+        :param length: the segment length
+        :return: True - this segment covers at least one site.
+        """
+        return self.sites.covers(pos, length)
+
+    def draw_any_site(self):
+        """
+        Uniform selection of a random site
+        :return: a cut-site
+        """
+        return self.sites.random_site()
+
+    def draw_any_location(self):
+        """
+        Uniform selection of any genomic coordinate for this replicon
+        :return: a genomic coord (zero based)
+        """
+        return pcg_integer(self.length)
+
+    @staticmethod
+    def get_loc_3c(emp_dist, pos1, length):
+        """
+        Get a second genomic location (pos2) on this replicon, where the separation |pos2-pos1|
+        is constrained by the experimentally determined distribution for 3C/HiC ligation
+        products.
+
+        TODO: this method does not explicitly treat linear replicons. To do so, we must
+           handle the edge case of drawing beyond first and last positions. Simple approaches
+           using redraw are potentially computationally terrible if the first position is
+           very close to the end of the replicon. For now, we accept the modulo solution
+           for both linear and circular.
+
+        :param emp_dist: empirical distribution of separation
+        :param pos1: the first position
+        :param length: the length (bp) of the replicon
+        :return: pos2: the second position
+        """
+        # draw a random separation
+        delta = int(emp_dist.rand())
+
+        # pve or nve shift, modulo length
+        if pcg_integer(2) == 0:
+            pos2 = (pos1 - delta) % length
+        else:
+            pos2 = (pos1 + delta) % length
+        return pos2
+
+    def _draw_simple_constrained_site(self, pos1):
+        """
+        Draw a second site (pos2) relative to the first (x1) which is constrained
+        to follow a basic empirical distribution.
+        :param pos1: the first location
+        :return: pos2: the second location
+        """
+        pos2 = Segment.get_loc_3c(self.empdist, pos1, self.length)
+
+        # anti-diagonal
+        if pcg_uniform() < self.anti_rate:
+            pos2 = self.length - pos2
+
+        # return nearest site
+        return self.sites.find_nn(pos2)
 
 
 class Replicon(object):
@@ -46,216 +216,162 @@ class Replicon(object):
     CID_MAX = 6
     CID_DEPTH = 2
 
-    def __init__(self, name, cell, cn, seq, enzyme, anti_rate, create_cids=True, linear=False):
+    def __init__(self, name, cell, cn):
         """
         The definition of a replicon (chromosome, plasmid, etc).
         :param name: a unique name for this replicon
         :param cell: the parent cell for this replicon
         :param cn: the copy-number of this replicon in 'cell'
-        :param seq: the genomic sequence of this replicon as a Bio.Seq object
-        :param enzyme: the enzyme used to digest this replicon as a Bio.Restriction RestrictionType
-        :param anti_rate: the rate of anti-diagonal interactions
-        :param create_cids: when true, simulate chromosome-interacting-domains
-        :param linear: treat replicon as linear
         """
 
-        self.linear = linear
         self.name = name
         self.copy_number = cn
-        self.seq = seq
+        # segment registry
+        self.segment_registry = OrderedDict()
+        self.cdf_extent = None
+        self.cdf_sites = None
+        self.segment_names = None
+        # TODO reimplement CID code for Segments
 
-        if self.linear:
-            if anti_rate > 0:
-                logger.warning('Replicon {} is linear, anti_rate of {} has been set to zero'
-                               .format(name, anti_rate))
-            self.anti_rate = 0
-        else:
-            self.anti_rate = anti_rate
-
-        # cut-site related properties. These are pre-calculated as a simple
-        # means of avoiding performance penalties with repeated calls.
-        if not enzyme:
-            self.sites = AllSites(len(seq.seq))
-        else:
-            self.sites = CutSites(enzyme, seq.seq, linear=linear)
-
-        self.length = len(self.seq)
-        self.num_sites = self.sites.size
-        self.site_density = self.num_sites / self.length
-
-        if create_cids:
-            # setup for more complex simulated CID model
-            self.draw_constrained_site = self._draw_cid_constrained_site
-            self.cid_blocks = cids_to_blocks(
-                generate_nested_cids(self.length, Replicon.BACKBONE_PROB,
-                                     Replicon.GLOBAL_EMPDIST_BINS, Replicon.GLOBAL_SHAPE_FACTOR,
-                                     Replicon.CID_EMPDIST_BINS, Replicon.CID_SHAPE_FACTOR,
-                                     cdf_alpha=Replicon.CDF_ALPHA,
-                                     min_num=Replicon.CID_MIN, max_num=Replicon.CID_MAX,
-                                     recur_depth=Replicon.CID_DEPTH))
-
-        else:
-            # setup for simple model
-            self.draw_constrained_site = self._draw_simple_constrained_site
-            self.empdist = EmpiricalDistribution(self.length,
-                                                 Replicon.GLOBAL_EMPDIST_BINS, cdf_geom_unif_ratio,
-                                                 cdf_alpha=Replicon.CDF_ALPHA,
-                                                 shape=Replicon.GLOBAL_SHAPE_FACTOR)
+        # if create_cids:
+        #     # setup for more complex simulated CID model
+        #     self.draw_constrained_site = self._draw_cid_constrained_site
+        #     self.cid_blocks = cids_to_blocks(
+        #         generate_nested_cids(self.length, Replicon.BACKBONE_PROB,
+        #                              Replicon.GLOBAL_EMPDIST_BINS, Replicon.GLOBAL_SHAPE_FACTOR,
+        #                              Replicon.CID_EMPDIST_BINS, Replicon.CID_SHAPE_FACTOR,
+        #                              cdf_alpha=Replicon.CDF_ALPHA,
+        #                              min_num=Replicon.CID_MIN, max_num=Replicon.CID_MAX,
+        #                              recur_depth=Replicon.CID_DEPTH))
+        #
+        # else:
+        #     # setup for simple model
+        #     self.draw_constrained_site = self._draw_simple_constrained_site
+        #     self.empdist = EmpiricalDistribution(self.length,
+        #                                          Replicon.GLOBAL_EMPDIST_BINS, cdf_geom_unif_ratio,
+        #                                          cdf_alpha=Replicon.CDF_ALPHA,
+        #                                          shape=Replicon.GLOBAL_SHAPE_FACTOR)
 
         # set bidirection association with containing cell
         self.parent_cell = cell
         cell.register_replicon(self)
 
     def __repr__(self):
-        return '{} {} {} {}'.format(self.name, self.parent_cell, self.sites.size, self.length)
+        return '{} {}'.format(self.name, self.parent_cell)
 
-    def covers_site(self, x, length):
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.name == other.name
+
+    def init_prob(self):
+        seg_info = self.get_segment_info()
+        pdf_extent = np.array(seg_info['length'], dtype='f8')
+        pdf_sites = np.array(seg_info['sites'], dtype='f8')
+        pdf_extent /= pdf_extent.sum()
+        pdf_sites /= pdf_sites.sum()
+        self.cdf_extent = np.cumsum(pdf_extent)
+        self.cdf_sites = np.cumsum(pdf_sites)
+        self.segment_names = np.array(seg_info['name'])
+
+    def get_length(self):
         """
-        Test if the segment defined by a position and length cover any cut-sites
-        for this replicon and enzyme digestion.
-        :param x: the beginning position
-        :param length: the segment length
-        :return: True - this segment covers at least one site.
+        :return: the length of this replicon
         """
-        return self.sites.covers(x, length)
+        return sum([seg.length for seg in self.segment_registry.values()])
 
-    def draw_any_site(self):
+    def get_num_sites(self):
         """
-        Uniform selection of a random site
-        :return: a cut-site
+        :return: the number of cut-sites for this replicon
         """
-        return self.sites.random_site()
+        return sum([seg.num_sites for seg in self.segment_registry.values()])
 
-    def draw_any_location(self):
+    def _max_name_len(self):
+        return max([len(seg.name) for seg in self.segment_registry.values()])
+
+    def get_segment_info(self):
         """
-        Uniform selection of any genomic coordinate for this replicon
-        :return: a genomic coord (zero based)
+        :return: a list of segment site counts
         """
-        return pcg_integer(self.length)
+        return np.array([(seg.name, seg.length, seg.num_sites) for seg in self.segment_registry.values()],
+                        dtype=np.dtype([('name', f'U{self._max_name_len()}'), ('length', 'i4'), ('sites', 'i4')]))
 
-    @staticmethod
-    def get_loc_3c(emp_dist, x1, length):
+    def register_segment(self, segment):
         """
-        Get a second genomic location (x2) on this replicon, where the separation |x2-x1|
-        is constrained by the experimentally determined distribution for 3C/HiC ligation
-        products.
-
-        TODO: this method does not explicitly treat linear replicons. To do so, we must
-           handle the edge case of drawing beyond first and last positions. Simple approaches
-           using redraw are potentially computationally terrible if the first position is
-           very close to the end of the replicon. For now, we accept the modulo solution
-           for both linear and circular.
-
-        :param emp_dist: empirical distribution of separation
-        :param x1: the first position
-        :param length: the length (bp) of the replicon
-        :return: x2: the second position
+        Insert a segment into this replicon's registry
+        :param segment: the segment to insert
+        :return: the inserted segment
         """
-        # draw a random separation
-        delta = int(emp_dist.rand())
+        assert isinstance(segment, Segment),  'Attempted to register invalid class.'
+        if segment.name in self.segment_registry:
+            raise Sim3CException('duplicate segment names')
+        self.segment_registry[segment.name] = segment
+        return segment
 
-        # pve or nve shift, modulo length
-        if pcg_integer(2) == 0:
-            x2 = (x1 - delta) % length
-        else:
-            x2 = (x1 + delta) % length
-        return x2
-
-    def _draw_simple_constrained_site(self, x1):
+    def draw_any_segment_by_sites(self):
         """
-        Draw a second site (x2) relative to the first (x1) which is constrained
-        to follow a basic empirical distribution.
-        :param x1: the first location
-        :return: x2: the second location
+        Draw any segment from the replicon, based on each segments number of sites
+        :return: a Segment
         """
-        x2 = Replicon.get_loc_3c(self.empdist, x1, self.length)
+        return self.segment_registry[cdf_choice(self.segment_names, self.cdf_sites)]
 
-        # anti-diagonal
-        if pcg_uniform() < self.anti_rate:
-            x2 = self.length - x2
-
-        # return nearest site
-        return self.sites.find_nn(x2)
-
-    def _draw_cid_constrained_site(self, x1):
+    def draw_any_segment_by_extent(self):
         """
-        Draw a second site (x2) relative to teh first (x1) which is constrained to follow
-        a nested hierarchy of empirical distributions, intended to simulate chromosomal
-        interaction domains (CID). Here, CIDs are small regions of a chromosome which interact
-        (possibly through folding) at a more frequent level than that of the overall backbone.
-
-        The range of effect of the CIDs are predetermined at instantiation time and stored as
-        intervals within an interval-tree. When called, x1 determines which overlapping intervals
-        are involved and single emp-dist (representing a particular CID) is chosen at random
-        (randomly weighted).
-
-        :param x1: the first location
-        :return: x2: the second location.
+        Draw any segment from the replicon, biased by the segment length.
+        :return: a Segment
         """
-        block = self.cid_blocks[x1].pop()
-        ovl_invs = block.data['inv_list']
+        return self.segment_registry[cdf_choice(self.segment_names, self.cdf_extent)]
 
-        if len(ovl_invs) == 1:
-            # only the background distribution governs this block
-            chosen_inv = ovl_invs[0]
+    # def _draw_cid_constrained_site(self, x1):
+    #     """
+    #     Draw a second site (x2) relative to teh first (x1) which is constrained to follow
+    #     a nested hierarchy of empirical distributions, intended to simulate chromosomal
+    #     interaction domains (CID). Here, CIDs are small regions of a chromosome which interact
+    #     (possibly through folding) at a more frequent level than that of the overall backbone.
+    #
+    #     The range of effect of the CIDs are predetermined at instantiation time and stored as
+    #     intervals within an interval-tree. When called, x1 determines which overlapping intervals
+    #     are involved and single emp-dist (representing a particular CID) is chosen at random
+    #     (randomly weighted).
+    #
+    #     :param x1: the first location
+    #     :return: x2: the second location.
+    #     """
+    #     block = self.cid_blocks[x1].pop()
+    #     ovl_invs = block.data['inv_list']
+    #
+    #     if len(ovl_invs) == 1:
+    #         # only the background distribution governs this block
+    #         chosen_inv = ovl_invs[0]
+    #
+    #         x2 = Replicon.get_loc_3c(chosen_inv.data['empdist'], x1, chosen_inv.length())
+    #
+    #         # anti-diagonal
+    #         if pcg_uniform() < self.anti_rate:
+    #             x2 = self.length - x2
+    #
+    #     else:
+    #         # pick a cid or background from those defined for this block
+    #         # note, numpy will not accept the list of intervals here
+    #         ix = np_choice(len(ovl_invs), p=block.data['prob_list'])
+    #         chosen_inv = ovl_invs[ix]
+    #
+    #         x2 = Replicon.get_loc_3c(chosen_inv.data['empdist'], x1 - chosen_inv.begin, chosen_inv.length())
+    #         x2 += chosen_inv.begin
+    #
+    #         # main backbone gets anti-diagonal treatment
+    #         if chosen_inv.data['depth'] == 0:
+    #             # antidiagonal
+    #             if pcg_uniform() < self.anti_rate:
+    #                 x2 = self.length - x2
+    #
+    #     return self.sites.find_nn(x2)
 
-            x2 = Replicon.get_loc_3c(chosen_inv.data['empdist'], x1, chosen_inv.length())
-
-            # anti-diagonal
-            if pcg_uniform() < self.anti_rate:
-                x2 = self.length - x2
-
-        else:
-            # pick a cid or background from those defined for this block
-            # note, numpy will not accept the list of intervals here
-            ix = np_choice(len(ovl_invs), p=block.data['prob_list'])
-            chosen_inv = ovl_invs[ix]
-
-            x2 = Replicon.get_loc_3c(chosen_inv.data['empdist'], x1 - chosen_inv.begin, chosen_inv.length())
-            x2 += chosen_inv.begin
-
-            # main backbone gets anti-diagonal treatment
-            if chosen_inv.data['depth'] == 0:
-                # antidiagonal
-                if pcg_uniform() < self.anti_rate:
-                    x2 = self.length - x2
-
-        return self.sites.find_nn(x2)
-
-    def subseq(self, x1, length, rev=False):
+    def num_segments(self):
         """
-        Create a subsequence.
-
-        :param x1: starting genomic position
-        :param length: length of subsequence
-        :param rev: reverse complement this sequence.
-        :return: subseq Seq object
+        :return: the number of segments for this replicon.
         """
-
-        # handle negative starts as wrapping around or,
-        # in linear cases, terminates at first position
-        if x1 < 0:
-            x1 = x1 % self.length if not self.linear else 0
-
-        x2 = x1 + length
-        diff = x2 - self.length
-        if diff > 0:
-            if self.linear:
-                # sequence terminates early
-                ss = self.seq[x1:-1]
-                ss.description = Replicon.PART_DESC_FMT.format(rev, x1+1, self.length)
-            else:
-                # sequence will wrap around
-                ss = self.seq[x1:] + self.seq[:diff]
-                ss.description = Replicon.PART_DESC_FMT.format(rev, x1+1, diff)
-        else:
-            ss = self.seq[x1:x2]
-            ss.description = Replicon.PART_DESC_FMT.format(rev, x1+1, x2)
-
-        if rev:
-            ss.reverse_complement(id=True, description=True)
-
-        return ss
+        return len(self.segment_registry)
 
 
 class Cell(object):
@@ -277,19 +393,19 @@ class Cell(object):
         self.abundance = abundance
         # replicons are kept in the order they are registered
         self.replicon_registry = OrderedDict()
+        self.segment_registry = OrderedDict()
         # inter-replicon (trans) rate
         self.trans_rate = trans_rate
 
         # probability properties, to be initialised by init_prob()
-        self.cdf = None
-        self.pdf = None
-        self.pdf_cn = None
-        self.pdf_extent = None
-        self.pdf_sites = None
-        self.cdf_cn = None
         self.cdf_extent = None
         self.cdf_sites = None
+        # for this cell, indices of segments within or outside replicons
+        # indices used with pdf and cdf arrays
+        self.cis_segment_indices = {}
+        self.trans_segment_indices = {}
         self.replicon_names = None
+        self.segment_names = None
         self.cdf_sites_inter = None
         self.cdf_extents_inter = None
 
@@ -302,6 +418,12 @@ class Cell(object):
         """
         return len(self.replicon_registry)
 
+    def num_segments(self):
+        """
+        :return: the number of segments for this cell.
+        """
+        return sum([rep.num_segments() for rep in self.replicon_registry.values()])
+
     def init_prob(self):
         """
         Initialise the selection probabilities. This method should be called after all replicons are
@@ -311,29 +433,47 @@ class Cell(object):
             raise NoRepliconsException(self.name)
 
         # begin with some empty PDFs
-        self.pdf_cn = np.zeros(self.num_replicons())
-        self.pdf_extent = np.zeros(self.num_replicons())
-        self.pdf_sites = np.zeros(self.num_replicons())
+        pdf_extent = np.zeros(self.num_segments())
+        pdf_sites = np.zeros(self.num_segments())
 
         # for each replicon, the PDF for the various modes of selection.
-        for i, k in enumerate(self.replicon_registry):
-            repl = self.replicon_registry[k]
+        i = 0
+        self.cis_segment_indices = OrderedDict()
+        for repl in self.replicon_registry.values():
+            repl.init_prob()
             cn = float(repl.copy_number)
-            self.pdf_cn[i] = cn
-            self.pdf_extent[i] = cn * repl.length
-            self.pdf_sites[i] = cn * repl.num_sites
+            seg_info = repl.get_segment_info()
+            self.cis_segment_indices[repl.name] = []
+            for si in seg_info:
+                pdf_extent[i] = cn * si['length']
+                pdf_sites[i] = cn * si['sites']
+                self.cis_segment_indices[repl.name].append(i)
+                i += 1
+
+        self.trans_segment_indices = OrderedDict()
+        for ri in self.cis_segment_indices:
+            self.trans_segment_indices[ri] = []
+            for rj, seg_idx in self.cis_segment_indices.items():
+                if ri != rj:
+                    self.trans_segment_indices[ri].extend(seg_idx)
 
         # normalise the PDFs
-        self.replicon_names = np.array([*self.replicon_registry])
-        self.pdf_cn /= self.pdf_cn.sum()
-        self.pdf_extent /= self.pdf_extent.sum()
-        self.pdf_sites /= self.pdf_sites.sum()
+        pdf_extent /= pdf_extent.sum()
+        pdf_sites /= pdf_sites.sum()
 
         # CDFs from the PDFs. Selection is accomplished by drawing a
         # unif([0..1]) and mapping that through the relevant CDF.
-        self.cdf_cn = np.cumsum(self.pdf_cn)
-        self.cdf_extent = np.cumsum(self.pdf_extent)
-        self.cdf_sites = np.cumsum(self.pdf_sites)
+        self.cdf_extent = np.cumsum(pdf_extent)
+        self.cdf_sites = np.cumsum(pdf_sites)
+
+        # array of names for extracting random sequences
+        self.replicon_names = np.array([*self.replicon_registry])
+
+        # prepare a registry of all defined segments for this replicon
+        for repl in self.replicon_registry.values():
+            for seg in repl.segment_registry.values():
+                self.segment_registry[seg.name] = seg
+        self.segment_names = np.array([*self.segment_registry])
 
         # One last set of CDFs for "select other" which exclude
         # each replicon in turn.
@@ -342,19 +482,20 @@ class Cell(object):
             self.cdf_sites_inter = {}
             self.cdf_extents_inter = {}
 
-            for ci in self.replicon_names:
-                # indices without ci
-                xi = np.where(self.replicon_names != ci)
+            for rn in self.replicon_names:
 
-                # site probs without ci
-                pi = self.pdf_sites[xi]
-                pi /= pi.sum()
-                self.cdf_sites_inter[ci] = {'names': self.replicon_names[xi], 'prob': np.cumsum(pi)}
+                # indices without rn
+                xi = self.trans_segment_indices[rn]
 
-                # extent probs without ci
-                pi = self.pdf_extent[xi]
+                # site probs without rn
+                pi = pdf_sites[xi]
                 pi /= pi.sum()
-                self.cdf_extents_inter[ci] = {'names': self.replicon_names[xi], 'prob': np.cumsum(pi)}
+                self.cdf_sites_inter[rn] = {'names': self.segment_names[xi], 'prob': np.cumsum(pi)}
+
+                # extent probs without rn
+                pi = pdf_extent[xi]
+                pi /= pi.sum()
+                self.cdf_extents_inter[rn] = {'names': self.segment_names[xi], 'prob': np.cumsum(pi)}
 
     def register_replicon(self, repl):
         """
@@ -363,59 +504,43 @@ class Cell(object):
         :return: the inserted replicon
         """
         assert isinstance(repl, Replicon),  'Attempted to register invalid class.'
-        if repl.name in self.replicon_registry:
-            raise Sim3CException('duplicate replicon names')
-        self.replicon_registry[repl.name] = repl
+        if repl.name not in self.replicon_registry:
+            self.replicon_registry[repl.name] = repl
         return repl
 
-    def get_replicon(self, name):
+    def draw_any_segment_by_extent(self):
         """
-        Return a replicon from the registry by name.
-        :param name: the name of the replicon
-        :return: the replicon
-        """
-        return self.replicon_registry[name]
-
-    def draw_replicon(self):
-        """
-        Draw any replicon from this cell, biased only by copy number.
-        :return: any replicon from this cell
-        """
-        return self.get_replicon(cdf_choice(self.replicon_names, self.cdf_cn))
-
-    def draw_any_replicon_by_extents(self):
-        """
-        Draw any replicon from this cell. The probability is biased by per-replicon
+        Draw any segment, replicon tuple from this cell. The probability is biased by per-replicon
         genomic extent and copy number.
-        :return: any replicon from this cell
+        :return: a segment,replicon tuple from this cell
         """
-        return self.get_replicon(cdf_choice(self.replicon_names, self.cdf_extent))
+        return self.segment_registry[cdf_choice(self.segment_names, self.cdf_extent)]
 
-    def draw_any_replicon_by_sites(self):
+    def draw_any_segment_by_sites(self):
         """
-        Draw any replicon from this cell. The probability is biased by per-replicon
+        Draw any segment, replicon tuple from this cell. The probability is biased by per-replicon
         number of sites and copy number.
-        :return: any replicon from this cell
+        :return: a segment, replicon tuple from this cell
         """
-        return self.get_replicon(cdf_choice(self.replicon_names, self.cdf_sites))
+        return self.segment_registry[cdf_choice(self.segment_names, self.cdf_sites)]
 
-    def draw_other_replicon_by_sites(self, skip_repl):
+    def draw_other_segment_by_sites(self, skip_repl):
         """
-        Draw a different replicon from this cell. The probability is biased by per-replicon
+        Draw a segment from a different replicon in this cell. The probability is biased by per-replicon
         number of sites and copy number. Note: single replicon cell definitions will
         raise an exception.
         :param skip_repl: the replicon to exclude
-        :return: another replicon from this cell
+        :return: segment of a different replicon in this cell
         """
         if self.num_replicons() <= 1:
             raise MonochromosomalException('inter-replicon events are not possible for monochromosomal cells')
 
-        return self.get_replicon(cdf_choice(self.cdf_sites_inter[skip_repl]['names'],
-                                            self.cdf_sites_inter[skip_repl]['prob']))
+        return self.segment_registry[cdf_choice(self.cdf_sites_inter[skip_repl]['names'],
+                                                self.cdf_sites_inter[skip_repl]['prob'])]
 
-    def draw_other_replicon_by_extents(self, skip_repl):
+    def draw_other_segment_by_extent(self, skip_repl):
         """
-        Draw a different replicon from this cell. The probability is biased by per-replicon
+        Draw a segment from adifferent replicon in this cell. The probability is biased by per-replicon
         extent and copy number. Note: single replicon cell definitions will
         raise an exception.
         :param skip_repl: the replicon to exclude
@@ -424,27 +549,26 @@ class Cell(object):
         if self.num_replicons() <= 1:
             raise MonochromosomalException('inter-replicon events are not possible for monochromosomal cells')
 
-        return self.get_replicon(cdf_choice(self.cdf_extents_inter[skip_repl]['names'],
-                                            self.cdf_extents_inter[skip_repl]['prob']))
+        return self.segment_registry[cdf_choice(self.cdf_extents_inter[skip_repl]['names'],
+                                                self.cdf_extents_inter[skip_repl]['prob'])]
 
     def draw_any_site(self):
         """
         Draw a cut-site from any replicon within this cell. The probability
         of drawing a replicon is biased by the per-replicon number of sites
         and copy number, while genomic location is uniform.
-        :return: a tuple of (replicon, location)
+        :return: a tuple of (segment, location)
         """
-        repl = self.draw_any_replicon_by_sites()
-        return repl, repl.draw_any_site()
+        segment = self.draw_any_segment_by_sites()
+        return segment, segment.draw_any_site()
 
     def print_report(self):
         """
         Print a simple report about this cell.
         """
         print(f'names {self.replicon_names}')
-        print(f'p_rep {self.pdf_cn}')
-        print(f'p_ext {self.pdf_extent}')
-        print(f'p_sit {self.pdf_sites}')
+        print(f'cdf_extent {self.cdf_extent}')
+        print(f'cdf_site {self.cdf_sites}')
 
     def is_trans(self):
         """
@@ -453,6 +577,7 @@ class Cell(object):
         :return: True -- treat this as a trans event
         """
         return self.num_replicons() > 1 and pcg_uniform() < self.trans_rate
+
 
 class Community(object):
     """
@@ -484,25 +609,26 @@ class Community(object):
         pcg_uniform = random.pcg_random.uniform
         pcg_integer = random.pcg_random.integer
 
-        # global replicon and cell registries
+        # global segment, replicon, and cell registries
+        self.segm_registry = OrderedDict()
         self.repl_registry = OrderedDict()
         self.cell_registry = OrderedDict()
 
         # initialise the registries using the community profile
-        for ri in profile.values():
+        for row_i in profile.values():
             # register the cell
-            cell = self._register_cell(Cell(ri.cell, ri.abundance, trans_rate))
-            # fetch the sequence from file
-            rseq = seq_index[ri.name].upper()
+            cell = self._register_cell(Cell(row_i.cell, row_i.abundance, trans_rate))
+            repl = self._register_replicon(Replicon(row_i.molecule, cell, row_i.copy_number))
             try:
+                # fetch the sequence from file
+                rseq = seq_index[row_i.name].upper()
                 # community-wide replicon registry
-                self._register_replicon(Replicon(ri.name, cell, ri.copy_number, rseq, enzyme,
-                                                 anti_rate, create_cids, linear))
+                self._register_segment(Segment(row_i.name, repl, rseq, enzyme, anti_rate, create_cids, linear))
             except NoCutSitesException:
                 logger.warning('Sequence "{}" had no cut-sites for the enzyme {} and will be ignored'.format(
-                    ri.name, str(enzyme)))
+                    row_i.name, str(enzyme)))
 
-        # now we're finished reading replicons, initialise the probs for each cell
+        # now we're finished reading the profile, initialise the probabilities for each cell
         for cell in self.cell_registry.values():
             try:
                 cell.init_prob()
@@ -511,42 +637,31 @@ class Community(object):
                 del self.cell_registry[cell.name]
 
         # now initialise the probs for the whole community
-        self.pdf_repl = np.zeros(len(self.repl_registry))
-        self.pdf_extent = np.zeros(len(self.repl_registry))
-        self.pdf_sites = np.zeros(len(self.repl_registry))
+        pdf_extent = np.zeros(len(self.segm_registry))
+        pdf_sites = np.zeros(len(self.segm_registry))
 
         # whether site (prox-lig) or extent (wgs) based, probs are
         # weighted by cellular abundance and copy number
-        for i, k in enumerate(self.repl_registry):
-            repl = self.repl_registry[k]
-            abn = repl.parent_cell.abundance
-            cn = repl.copy_number
-            self.pdf_repl[i] = abn * cn
-            self.pdf_extent[i] = abn * cn * repl.length
-            self.pdf_sites[i] = abn * cn * repl.num_sites
+        i = 0
+        for repl in self.repl_registry.values():
+            cn = float(repl.copy_number)
+            seg_info = repl.get_segment_info()
+            for si in seg_info:
+                pdf_extent[i] = cn * si['length']
+                pdf_sites[i] = cn * si['sites']
+                i += 1
 
         # now normalise pdfs
-        self.pdf_repl /= self.pdf_repl.sum()
-        self.pdf_extent /= self.pdf_extent.sum()
-        self.pdf_sites /= self.pdf_sites.sum()
+        pdf_extent /= pdf_extent.sum()
+        pdf_sites /= pdf_sites.sum()
 
         # derive cdfs from pdfs, these are what's used for drawing values
-        self.cdf_repl = np.cumsum(self.pdf_repl)
-        self.cdf_extent = np.cumsum(self.pdf_extent)
-        self.cdf_sites = np.cumsum(self.pdf_sites)
+        self.cdf_extent = np.cumsum(pdf_extent)
+        self.cdf_sites = np.cumsum(pdf_sites)
 
-        # keep a list of chr names in numpy format
+        # keep a list of names in numpy format
         self.repl_names = np.array([*self.repl_registry])
-
-        # setup pdfs and cdfs for inter-cellular events
-        # each represents a deletion of one chr and renormalisation
-        if len(self.repl_registry) > 1:
-            self.cdf_sites_inter = {}
-            for rni in self.repl_names:
-                ix = np.where(self.repl_names != rni)
-                pi = self.pdf_sites[ix]
-                pi /= pi.sum()
-                self.cdf_sites_inter[rni] = {'names': self.repl_names[ix], 'prob': np.cumsum(pi)}
+        self.segm_names = np.array([*self.segm_registry])
 
         # inter-cellular rate is scaled by the product of all chrom site probs
         self.spurious_rate = spurious_rate
@@ -556,10 +671,10 @@ class Community(object):
 
         # we must have at least one cell defined
         if self.num_cells <= 0:
-            logger.error('Community did not contain any useful cells. '
-                         'Check that your reference sequence(s) were '
-                         'valid and that they each contain at least one cut-site.')
-            raise Sim3CException('Community is empty')
+            logger.error('Community did not contain any useful cell definitions. '
+                         'Check that your reference sequence(s) were valid and '
+                         'that they each contain at least one cut-site.')
+            raise Sim3CException('Community contains no cells')
 
     def _register_cell(self, cell):
         """
@@ -579,10 +694,29 @@ class Community(object):
         :return: the added replicon instance
         """
         assert isinstance(repl, Replicon),  'Attempted to register invalid class.'
-        if repl.name in self.repl_registry:
-            raise Sim3CException('duplicate replicon names in community')
-        self.repl_registry[repl.name] = repl
-        return repl
+        if repl.name not in self.repl_registry:
+            self.repl_registry[repl.name] = repl
+        return self.repl_registry[repl.name]
+
+    def _register_segment(self, segment):
+        """
+        Add an instance of Segment to the segment registry
+        :param segment:
+        :return: the added segment instance
+        """
+        assert isinstance(segment, Segment),  'Attempted to register invalid class.'
+        if segment.name in self.segm_registry:
+            raise Sim3CException('duplicate segment names in community')
+        self.segm_registry[segment.name] = segment
+        return segment
+
+    def get_segment(self, name):
+        """
+        Return a segment from the registry
+        :param name: the name of the segment
+        :return: the Segment instance
+        """
+        return self.segm_registry[name]
 
     def get_repl(self, name):
         """
@@ -590,7 +724,6 @@ class Community(object):
         :param name: the name of the replicon
         :return: the Replicon instance
         """
-
         return self.repl_registry[name]
 
     def get_cell(self, name):
@@ -601,61 +734,42 @@ class Community(object):
         """
         return self.cell_registry[name]
 
-    def draw_repl(self):
-        """
-        Draw any replicon from this community, biased relative abundance and copy number.
-        :return: any replicon from this community
-        """
-        return self.get_repl(cdf_choice(self.repl_names, self.cdf_repl))
-
-    def draw_any_repl_by_extent(self):
+    def draw_any_segment_by_extent(self):
         """
         Draw any replicon from this community. The probability is biased by cellular abundance,
         and per-replicon genomic extent and copy number.
         :return: any replicon from this community
         """
-        return self.get_repl(cdf_choice(self.repl_names, self.cdf_extent))
+        return self.segm_registry[cdf_choice(self.segm_names, self.cdf_extent)]
 
-    def draw_any_repl_by_sites(self):
+    def draw_any_segment_by_sites(self):
         """
         Draw any replicon from this community. The probability is biased by cellular abundance,
         and per-replicon number of cut-sites and copy number.
         :return: any replicon from this community
         """
-        return self.get_repl(cdf_choice(self.repl_names, self.cdf_sites))
-
-    def draw_other_repl_by_sites(self, skip_repl):
-        """
-        Draw a different replicon from this community. The probability is biased by cellular abundance,
-        per-replicon number of sites and copy number. Note: single replicon cell definitions will
-        raise an exception.
-        :param skip_repl: the replicon to exclude
-        :return: another replicon from this cell
-        """
-        return self.get_repl(cdf_choice(self.cdf_sites_inter[skip_repl]['names'],
-                                        self.cdf_sites_inter[skip_repl]['prob']))
+        return self.segm_registry[cdf_choice(self.segm_names, self.cdf_sites)]
 
     def draw_any_by_site(self):
         """
         Draw any site from any replicon, biased by abundance, number of sites and copy number.
         :return:
         """
-        repl = self.draw_any_repl_by_sites()
-        return repl, repl.draw_any_site()
+        segment = self.draw_any_segment_by_sites()
+        return segment, segment.draw_any_site()
 
     def draw_any_by_extent(self):
         """
         Draw any site from any replicon, biased by abundance, number of sites and copy number.
         :return:
         """
-        repl = self.draw_any_repl_by_extent()
-        return repl, repl.draw_any_location()
+        segment = self.draw_any_segment_by_extent()
+        return segment, segment.draw_any_location()
 
     def print_report(self):
         print(f'names {self.repl_names}')
-        print(f'p_rep {self.pdf_repl}')
-        print(f'p_ext {self.pdf_extent}')
-        print(f'p_sit {self.pdf_sites}')
+        print(f'cdf_ext {self.cdf_extent}')
+        print(f'cdf_sit {self.cdf_sites}')
 
     def is_spurious(self):
         """

--- a/sim3C/site_analysis.py
+++ b/sim3C/site_analysis.py
@@ -4,7 +4,7 @@ from Bio.Restriction import Restriction
 from Bio.Restriction.Restriction_Dictionary import rest_dict, typedict
 
 from .exceptions import *
-from .random import np_randint
+import sim3C.random as random
 
 
 def get_enzyme_instance_ipython(enz_name):
@@ -81,7 +81,7 @@ class CutSites(object):
         Select a uniformly random site
         :return: a random site
         """
-        return self.sites[np_randint(self.size)]
+        return self.sites[random.pcg_random.integer(self.size)]
 
     def _covers_site_linear(self, x1: np.ndarray, length):
         """
@@ -204,7 +204,7 @@ class AllSites(object):
         Draw a random base-position uniformly over the entire extent (0..size-1).
         :return: random base position (0-based)
         """
-        return np_randint(self.size)
+        return random.pcg_random.integer(self.size)
 
     @staticmethod
     def find_nn(pos):


### PR DESCRIPTION
Resolving issue #29 was accomplished by definition a community profile object hierarchy, to include the notion of a `Molecule` which contains `Segments`. This replaces the bottom-most object which was merely the sequence records.

Now, users must specify in the community profile the molecule to which each sequence belongs. This allows the use of draft genomes -- which dominate the public sequence databases.

The tab-delimited flat community profile table now included a 4th mandatory column. The keys used for molecules are not special and can be whatever the user chooses. The header column is not required and any line beginning with a `#` is treated as a comment.

```
#chrom    cell     molecule      abundance    copy_number
contig1   e.coli   chromosome    0.6           1
contig2   e.coli   chromosome    0.2           1
contig3   e.coli   plasmid       0.1           4
contig4   b.subt   chrom_xyz     0.05          1
contig5   s.aur    foobar        0.05          1
```