### PR TITLE
Update command_line.py, fixing error with depracted argument

### DIFF
--- a/sim3C/command_line.py
+++ b/sim3C/command_line.py
@@ -193,7 +193,7 @@ def main():
                 logger.error('Arguments to profile-name should not contain path information')
                 sys.exit(1)
 
-            profile_path = os.path.join(os.path.dirname(args.output_file), args.profile_name)
+            profile_path = os.path.join(os.path.dirname(args.output_file_1), args.profile_name)
             if os.path.exists(profile_path):
                 logger.error('Delete or move previous procedural abundance profile: {}'.format(profile_path))
                 sys.exit(1)


### PR DESCRIPTION
Fixed typo when creating profile_path, in `command_line.py` line 196. This fixes the issue #39. I have used `args.output_file_1`, not sure if you guys want to use another convention or argument. I hope this is useful!